### PR TITLE
Add option for comparing NuGet structure and NuGet metadata.

### DIFF
--- a/Mono.ApiTools.NuGetDiff/NuGetDiffResult.cs
+++ b/Mono.ApiTools.NuGetDiff/NuGetDiffResult.cs
@@ -35,6 +35,14 @@ namespace Mono.ApiTools
 
 		public Dictionary<NuGetFramework, (string newPath, string oldPath)[]> SimilarAssemblies { get; set; }
 
+		// file diff
+
+		public List<string> AddedFiles { get; } = new List<string>();
+
+		public List<string> RemovedFiles { get; } = new List<string>();
+
+		public List<NuGetSpecDiff.ElementDiff> MetadataDiff { get; } = new List<NuGetSpecDiff.ElementDiff>();
+
 		public NuGetFramework[] GetAllFrameworks()
 		{
 			return

--- a/Mono.ApiTools.NuGetDiff/NuGetSpecDiff.cs
+++ b/Mono.ApiTools.NuGetDiff/NuGetSpecDiff.cs
@@ -1,0 +1,121 @@
+﻿using NuGet.Packaging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace Mono.ApiTools
+{
+	public class NuGetSpecDiff
+	{
+		static readonly Regex tag = new Regex("artifact_versioned=(?<GroupId>.+)?:(?<ArtifactId>.+?):(?<Version>.+)\\s?", RegexOptions.Compiled);
+
+		public static IEnumerable<ElementDiff> Generate(PackageArchiveReader oldReader, PackageArchiveReader newReader, bool skipVersionMetadata)
+		{
+			// make a copy so we aren't modifying the *real* nuspec
+			var oldMetadata = new XDocument(oldReader?.NuspecReader?.Xml ?? XDocument.Parse("<package><metadata /></package>")).StripAllNamespaces();
+			var newMetadata = new XDocument(newReader?.NuspecReader?.Xml ?? XDocument.Parse("<package><metadata /></package>")).StripAllNamespaces();
+
+			if (oldMetadata.Element("package")?.Element("metadata") is not XElement oldXml || newMetadata.Element("package")?.Element("metadata") is not XElement newXml)
+				throw new ArgumentException("Malformed Nuspec xml");
+
+			if (skipVersionMetadata)
+			{
+				StripVersionMetadata(oldMetadata);
+				StripVersionMetadata(newMetadata);
+			}
+
+			var allElements = oldXml.Elements().Concat(newXml.Elements()).Select(x => x.Name.LocalName).Distinct();
+			var allDiffs = new List<ElementDiff>();
+
+			foreach (var element in allElements)
+			{
+				var diff = new ElementDiff(oldXml.Element(element), newXml.Element(element));
+
+				if (diff.Type != DiffType.None)
+					allDiffs.Add(diff);
+			}
+
+
+			return allDiffs;
+		}
+
+		static void StripVersionMetadata(XDocument xml)
+		{
+			if (xml.Element("package")?.Element("metadata") is not XElement metadata)
+				return;
+
+			// strip metadata that changes on every release, like version and git branch/commit
+			metadata.Element("version")?.Remove();
+
+			if (metadata.Element("repository") is XElement repo)
+			{
+				repo.Attribute("branch")?.Remove();
+				repo.Attribute("commit")?.Remove();
+			}
+
+			// strip a custom tag that AndroidX/GPS uses that contains a version number
+			// ex: artifact_versioned=com.google.code.gson:gson:2.10.1
+			if (metadata.Element("tags") is XElement tags)
+			{
+				var match = tag.Match(tags.Value);
+
+				if (match.Success)
+					tags.Value = tags.Value.Replace(match.Groups["Version"].Value, "[Version]");
+			}
+		}
+
+		public class ElementDiff
+		{
+			public XElement OldElement { get; }
+			public XElement NewElement { get; }
+
+			public ElementDiff(XElement oldElement, XElement newElement)
+			{
+				OldElement = oldElement;
+				NewElement = newElement;
+			}
+
+			public string Name => OldElement?.Name?.LocalName ?? NewElement?.Name?.LocalName;
+
+			public DiffType Type
+			{
+				get
+				{
+					if (OldElement is null)
+						return DiffType.Added;
+					if (NewElement is null)
+						return DiffType.Removed;
+					if (OldElement.Value == NewElement.Value)
+						return DiffType.None;
+
+					return DiffType.Modified;
+				}
+			}
+
+			public string ToFormattedString()
+			{
+				switch (Type)
+				{
+					case DiffType.Added:
+						return NewElement.GetPrefixedString("+");
+					case DiffType.Removed:
+						return OldElement.GetPrefixedString("-");
+					case DiffType.Modified:
+						return $"{OldElement.GetPrefixedString("-")}{Environment.NewLine}{NewElement.GetPrefixedString("+")}";
+				}
+
+				return string.Empty;
+			}
+		}
+
+		public enum DiffType
+		{
+			None,
+			Added,
+			Removed,
+			Modified
+		}
+	}
+}

--- a/Mono.ApiTools.NuGetDiff/XElementExtensions.cs
+++ b/Mono.ApiTools.NuGetDiff/XElementExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Xml.Linq;
+
+namespace Mono.ApiTools
+{
+	internal static class XElementExtensions
+	{
+		internal static XDocument StripAllNamespaces(this XDocument document)
+		{
+			foreach (var node in document.Root.DescendantsAndSelf())
+				node.Name = node.Name.LocalName;
+
+			return document;
+		}
+
+		internal static string GetPrefixedString(this XElement element, string prefix)
+			=> element.ToString().PrefixLines(prefix);
+
+		internal static string PrefixLines(this string str, string prefix)
+		{
+			var sb = new StringBuilder();
+
+			using var sr = new StringReader(str);
+
+			while (sr.ReadLine() is string line)
+				sb.AppendLine($"{prefix} {line}");
+
+			return sb.ToString().Trim();
+		}
+	}
+}

--- a/api-tools/NuGetDiffCommand.cs
+++ b/api-tools/NuGetDiffCommand.cs
@@ -38,6 +38,8 @@ namespace Mono.ApiTools
 
 		public string SourceUrl { get; set; } = "https://api.nuget.org/v3/index.json";
 
+		public bool CompareNuGetStructure { get; set; }
+
 		protected override OptionSet OnCreateOptions() => new OptionSet
 		{
 			{ "cache=", "The package cache directory", v => PackageCache = v },
@@ -50,6 +52,7 @@ namespace Mono.ApiTools
 			{ "search-path=", "A search path directory", v => SearchPaths.Add(v) },
 			{ "source=", "The NuGet URL source", v => SourceUrl = v },
 			{ "version=", "The version of the package to compare", v => Version = v },
+			{ "compare-nuget-structure", "Compare NuGet metadata and file contents", v => CompareNuGetStructure = true },
 		};
 
 		protected override bool OnValidateArguments(IEnumerable<string> extras)
@@ -203,6 +206,8 @@ namespace Mono.ApiTools
 			comparer.IgnoreResolutionErrors = true;                 // we don't care if frameowrk/platform types can't be found
 			comparer.MarkdownDiffFileExtension = ".diff.md";
 			comparer.IgnoreNonBreakingChanges = false;
+			comparer.SaveNuGetStructureDiff = CompareNuGetStructure;
+
 			await comparer.SaveCompleteDiffToDirectoryAsync(olderReader, reader, diffRoot);
 
 			// run the diff with just the breaking changes


### PR DESCRIPTION
Currently, we use `api-tools` in AndroidX and GooglePlayServices repositories to help us verify changes to C# APIs when we make binding changes.

However, there are some additional scenarios we would like to verify changes to:
- Changes to the NuGet metadata, like `<title>` or `<description>`
- Changes to the files contained in the NuGet package, like to ensure that a needed `.targets` file doesn't disappear
  - Note this is only comparing which files *exist* in the package, not if the file contents changed

These additional checks will help give us more confidence to update our project file templates without silently breaking packages.

Implemented as a new option:
```
api-tools nuget-diff --compare-nuget-structure
```

If there are changes to NuGet metadata or contents, this will produce a file called `nuget-diff.md` in the output directory.  This file looks like:


    ## Xamarin.AndroidX.Window

    ### Changed Metadata

    ```
    - <title>.NET for Android (formerly Xamarin.Android) AndroidX - window</title>
    + <title>.NET for Android AndroidX - window</title>
    ```

    ### Added/Removed File(s)

    ```
    - lib/monoandroid12.0/Xamarin.AndroidX.Window.pdb
    - lib/net6.0-android31.0/Xamarin.AndroidX.Window.pdb
    ```
